### PR TITLE
Load cloud settings "draculatheme"

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,3 +15,5 @@ var dracula=["7=282a36","8=f8f8f2","9=50fa7b","ae=t","t=p","s=m","w=n","m=l","o=
 Or you can use [TamperMonkey](https://www.tampermonkey.net) instead. [Click here](https://github.com/dracula/duckduckgo/raw/master/monkeyscript.user.js) to install the user script
 
 If you want to make your own changes, visit: https://duckduckgo.com/settings
+
+Alternatively, you may load cloud settings "draculatheme"


### PR DESCRIPTION
As the url bar method doesn't work anymore, this would be a quick way to install the dracula theme to duckduckgo