### PR TITLE
Update js script to url match DuckDuckGo settings url

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,6 @@ Save it by pasting this script in your browser console while browsing https://du
 var dracula=["7=282a36","8=f8f8f2","9=50fa7b","ae=t","t=p","s=m","w=n","m=l","o=s","j=282a36","a=p","aa=bd93f9","u=-1","x=f1fa8c","y=44475a","af=1","ai=1","f=1"];for(var i=0;i<dracula.length;i++)document.cookie=dracula[i];alert('Appearance settings have successfully been updated!');location.reload();
 ```
 
-Or you can use [TamperMonkey](https://www.tampermonkey.net) instead. [Click here](https://github.com/dracula/duckduckgo/raw/master/monkeyscript.user.js) to install the user script
+Or you can use [TamperMonkey](https://www.tampermonkey.net) instead. [Click here](https://github.com/dracula/duckduckgo/raw/master/monkeyscript.user.js) to install the user script. You must navigate to https://duckduckgo.com/settings for the theme to apply
 
 If you want to make your own changes, visit: https://duckduckgo.com/settings

--- a/monkeyscript.user.js
+++ b/monkeyscript.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        DuckDuckGo Dracula Dark Theme
 // @namespace   https://duckduckgo.com/
-// @match       https://duckduckgo.com/
+// @match       https://duckduckgo.com/settings
 // @grant       none
 // @version     1.0
 // @author      -


### PR DESCRIPTION
Current script doesnt seem to work anymore and url match doesnt work because you have to be on settings page now it seems for theme to apply. Updated INSTALL.md to clarify this as well as updated match url for monkey script